### PR TITLE
[codex] Remove hash URLs from sitemap

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -11,43 +11,4 @@
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
-
-  <!-- Portfolio sections (anchor links for SPA) -->
-  <url>
-    <loc>https://theodorosmentis.com/#experience</loc>
-    <lastmod>2025-12-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://theodorosmentis.com/#skills</loc>
-    <lastmod>2025-12-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-
-  <url>
-    <loc>https://theodorosmentis.com/#projects</loc>
-    <lastmod>2025-12-23</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://theodorosmentis.com/#certificates</loc>
-    <lastmod>2025-12-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-
-  <url>
-    <loc>https://theodorosmentis.com/#about</loc>
-    <lastmod>2025-12-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-
-  <url>
-    <loc>https://theodorosmentis.com/#contact</loc>
-    <lastmod>2025-12-23</lastmod>
+</urlset>


### PR DESCRIPTION
## Summary

Removes SPA hash-fragment URLs from `public/sitemap.xml` so the sitemap only lists the canonical crawlable homepage URL.

## Why

Search engines ignore URL fragments for sitemap discovery, so entries like `/#experience`, `/#projects`, and `/#contact` are not distinct crawlable URLs and can fail sitemap expectations.

## Validation

- `node -e "..."` assertion verified the sitemap has one canonical `<loc>` and no `#` fragments.
- `npm run build`

Note: `xmllint` is not installed in the local environment, so XML validation was covered by the local sitemap assertions and production build.