### PR TITLE
[codex] fix TypeScript type-check errors

### DIFF
--- a/src/components/ModernBio.tsx
+++ b/src/components/ModernBio.tsx
@@ -37,9 +37,8 @@ interface StatItem {
 
 interface ColorClasses {
   bg: string
-  icon: string
-  label: string
-  value: string
+  text: string
+  border: string
 }
 
 const StatsCard = memo(

--- a/src/components/ModernProjects.tsx
+++ b/src/components/ModernProjects.tsx
@@ -128,8 +128,8 @@ const ModernProjects = memo(() => {
   }, [])
 
   const validatedProjects = useMemo(() => {
-    return myProjects
-      .filter((project: Project): project is Project => isValidProject(project))
+    return (myProjects as unknown[])
+      .filter(isValidProject)
       .map((project, index) => ({
         ...project,
         id: `project-${index}-${project.prName

--- a/src/components/ReactProjects.tsx
+++ b/src/components/ReactProjects.tsx
@@ -2,7 +2,6 @@ import React, { memo, useMemo, useState } from "react"
 import { useTheme } from "../context/ThemeContext"
 import useIntersectionObserver from "../hooks/useIntersectionObserver"
 import { validateReactProject } from "../utils/validation"
-import { ModernReactProject } from "../types"
 import reactProjectsData from "../assets/myReactProjects.json"
 import { Code2, ExternalLink, Github, Zap, Star, Calendar } from "lucide-react"
 import { NoDataAvailable } from "./ui/EmptyState"
@@ -17,10 +16,7 @@ const ReactProjects: React.FC = memo(() => {
   const [hoveredProject, setHoveredProject] = useState<string | null>(null)
 
   const validReactProjects = useMemo(() => {
-    return reactProjectsData.filter(
-      (project: ModernReactProject): project is ModernReactProject =>
-        validateReactProject(project)
-    )
+    return (reactProjectsData as unknown[]).filter(validateReactProject)
   }, [])
 
   if (validReactProjects.length === 0) {

--- a/src/components/modern/ModernProjectGrid.tsx
+++ b/src/components/modern/ModernProjectGrid.tsx
@@ -402,8 +402,8 @@ const ModernProjectGrid: React.FC<ModernProjectGridProps> = ({
               {filteredProjects.length === 0 && !loading && (
                 <NoProjectsFound
                   onResetFilter={
-                    activeFilter !== "all"
-                      ? () => setActiveFilter("all")
+                    selectedCategory !== "all"
+                      ? () => setSelectedCategory("all")
                       : undefined
                   }
                 />

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -104,7 +104,7 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
     ? {
         initial: { opacity: 0, y: 20 },
         animate: { opacity: 1, y: 0 },
-        transition: { duration: 0.5, ease: "easeOut" },
+        transition: { duration: 0.5, ease: "easeOut" as const },
       }
     : {}
 
@@ -112,7 +112,7 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
     ? {
         initial: { scale: 0.8, opacity: 0 },
         animate: { scale: 1, opacity: 1 },
-        transition: { delay: 0.1, duration: 0.4, type: "spring" },
+        transition: { delay: 0.1, duration: 0.4, type: "spring" as const },
       }
     : {}
 

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -12,6 +12,19 @@ declare module "*.webp" {
   export default content
 }
 
+declare const process: {
+  env: {
+    NODE_ENV?: "development" | "production" | "test"
+    VERCEL?: string
+    VITE_VERCEL_ANALYTICS_ENABLED?: string
+    VITE_VERCEL_SPEED_INSIGHTS_ENABLED?: string
+  }
+}
+
+declare const describe: typeof import("vitest")["describe"]
+declare const it: typeof import("vitest")["it"]
+declare const expect: typeof import("vitest")["expect"]
+
 interface ImportMeta {
   env: {
     MODE: string

--- a/src/design-system/theme.ts
+++ b/src/design-system/theme.ts
@@ -49,7 +49,7 @@ export const useDesignSystem = () => {
       for (const key of keys) {
         value = value[key]
       }
-      return value as string
+      return value as unknown as string
     },
     typography: (size: keyof typeof tokens.typography.fontSizes) => ({
       fontSize: tokens.typography.fontSizes[size],

--- a/src/utils/postHogAnalytics.ts
+++ b/src/utils/postHogAnalytics.ts
@@ -25,7 +25,7 @@ class PostHogAnalytics {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  initialize(config: PostHogConfig) {
+  initialize(_config: PostHogConfig) {
     console.warn(
       "PostHogAnalytics.initialize() is deprecated. Use PostHogProvider instead."
     )

--- a/src/utils/productionMonitor.ts
+++ b/src/utils/productionMonitor.ts
@@ -40,7 +40,7 @@ interface PerformanceReport {
     used: number
     total: number
     limit: number
-  }
+  } | null
 }
 
 class ProductionMonitor {

--- a/src/utils/schemaValidator.ts
+++ b/src/utils/schemaValidator.ts
@@ -1,5 +1,4 @@
 import type {
-  SchemaOrgType,
   SchemaOrgCreativeWork,
   SchemaOrgWebSite,
   SchemaOrgItemList,
@@ -14,7 +13,7 @@ export interface SchemaValidationResult {
   suggestions: string[]
 }
 
-type SchemaInput = SchemaOrgType | UnknownObject
+type SchemaInput = UnknownObject
 
 export class SchemaValidator {
   static validateSchemaInConsole() {
@@ -104,7 +103,7 @@ export class SchemaValidator {
     const warnings: string[] = []
     const suggestions: string[] = []
 
-    const schemaObj = schema as SchemaOrgWebSite
+    const schemaObj = schema as unknown as SchemaOrgWebSite
     if (!schemaObj.url) errors.push("Website schema missing URL")
     if (!schemaObj.name) errors.push("Website schema missing name")
 
@@ -129,7 +128,7 @@ export class SchemaValidator {
     const warnings: string[] = []
     const suggestions: string[] = []
 
-    const schemaObj = schema as SchemaOrgItemList
+    const schemaObj = schema as unknown as SchemaOrgItemList
     if (
       !schemaObj.itemListElement ||
       !Array.isArray(schemaObj.itemListElement)
@@ -155,7 +154,7 @@ export class SchemaValidator {
     const warnings: string[] = []
     const suggestions: string[] = []
 
-    const schemaObj = schema as SchemaOrgOrganization
+    const schemaObj = schema as unknown as SchemaOrgOrganization
     if (!schemaObj.name) errors.push("Organization schema missing 'name'")
 
     if (!schemaObj.url) warnings.push("Consider adding 'url' field")
@@ -241,7 +240,7 @@ export class SchemaValidator {
   }
 
   static optimizeSchema<T extends SchemaInput>(schema: T): T {
-    const optimized = { ...schema } as T & UnknownObject
+    const optimized: UnknownObject = { ...schema }
 
     if (!optimized["@context"]) {
       optimized["@context"] = "https://schema.org"

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -47,7 +47,7 @@ export const isValidReactProject = (
   )
 }
 
-export const validateReactProject = (obj: unknown): boolean => {
+export const validateReactProject = (obj: unknown): obj is ModernReactProject => {
   if (typeof obj !== "object" || obj === null) return false
   const project = obj as Record<string, unknown>
   return (


### PR DESCRIPTION
## Summary

Fixes the TypeScript failures currently blocking `npm run type-check` on main.

The changes keep the existing architecture intact and address the reported compiler errors by:
- adding narrow ambient declarations for existing runtime/test globals
- tightening JSON validation flows to start from `unknown`
- aligning local interfaces and casts with the shapes already used at runtime
- fixing the stale `activeFilter` reset reference in `ModernProjectGrid`
- resolving strict Framer Motion transition literal typing

## Root Cause

`tsc --noEmit` was being run with strict settings against code that relied on inferred JSON shapes, existing globals without declarations, and a few stale or overly narrow local types. Those surfaced as compile errors once type-checking was enforced.

## Validation

- `npm run type-check`
- `npm run test`
- `npm run lint` (passes with existing Fast Refresh warnings)
- `npm run build`