### PR TITLE
[codex] Align CI Node version with nvmrc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: .nvmrc
           cache: npm
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

- Update the CI setup-node configuration to read the Node.js version from `.nvmrc`.
- Keep CI on Node 22 while preventing drift from the repository runtime configuration.

## Root Cause

The Node.js version was maintained separately in CI from `.nvmrc`, which can allow the CI runtime to drift from the package engine and local development version.

## Validation

- `node -v` -> `v22.22.0`
- `npm ci`
- `npm run build`