### PR TITLE
fix: harden production CSP and consolidate headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,12 +49,6 @@
     <meta name="author" content="Theodoros Mentis" />
     <meta name="robots" content="index, follow" />
 
-    <!-- Content Security Policy -->
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.emailjs.com https://va.vercel-scripts.com https://vitals.vercel-insights.com https://eu-assets.i.posthog.com https://app.posthog.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://api.emailjs.com https://va.vercel-scripts.com https://vitals.vercel-insights.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://app.posthog.com https://fonts.googleapis.com https://fonts.gstatic.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests;"
-    />
-
     <!-- Language and Region Meta Tags -->
     <meta name="language" content="en" />
     <meta http-equiv="content-language" content="en" />

--- a/src/middleware/security.middleware.ts
+++ b/src/middleware/security.middleware.ts
@@ -1,61 +1,12 @@
-import { securityConfig } from "../utils/security"
+import { getAllSecurityHeaders, securityConfig } from "../utils/security"
 
 export interface SecurityHeaders {
   [key: string]: string
 }
 
 export function getSecurityHeaders(): SecurityHeaders {
-  const csp = [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline' https://cdn.emailjs.com https://va.vercel-scripts.com https://vitals.vercel-insights.com https://eu-assets.i.posthog.com https://app.posthog.com",
-    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-    "font-src 'self' https://fonts.gstatic.com",
-    "img-src 'self' data: https:",
-    "connect-src 'self' https://api.emailjs.com https://vitals.vercel-insights.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://app.posthog.com https://fonts.googleapis.com https://fonts.gstatic.com",
-    "frame-ancestors 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "object-src 'none'",
-    "upgrade-insecure-requests",
-  ]
-    .filter(Boolean)
-    .join("; ")
-
-  return {
-    "Content-Security-Policy": csp,
-
-    "X-XSS-Protection": "1; mode=block",
-
-    "X-Content-Type-Options": "nosniff",
-
-    "X-Frame-Options": "DENY",
-
-    "Referrer-Policy": "strict-origin-when-cross-origin",
-
-    "Permissions-Policy": [
-      "camera=()",
-      "microphone=()",
-      "geolocation=()",
-      "payment=()",
-      "usb=()",
-      "bluetooth=()",
-      "magnetometer=()",
-      "gyroscope=()",
-      "accelerometer=()",
-    ].join(", "),
-
-    "Cross-Origin-Embedder-Policy": "require-corp",
-    "Cross-Origin-Opener-Policy": "same-origin",
-    "Cross-Origin-Resource-Policy": "same-origin",
-
-    "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-
-    "Expect-CT": "max-age=86400, enforce",
-
-    "Cache-Control": "no-store, no-cache, must-revalidate, proxy-revalidate",
-    Pragma: "no-cache",
-    Expires: "0",
-  }
+  const isDevelopment = process.env.NODE_ENV !== "production"
+  return getAllSecurityHeaders(isDevelopment)
 }
 
 // Express middleware types - using any for framework compatibility

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -2,7 +2,6 @@ export const securityConfig = {
   csp: {
     scriptSrc: [
       "'self'",
-      "'unsafe-inline'", // Required for development - remove in production
       "https://cdnjs.cloudflare.com",
       "https://cdn.emailjs.com",
       "https://www.googletagmanager.com", // For analytics
@@ -177,14 +176,15 @@ export const securityConfig = {
 
 export const generateCSPHeader = (isDevelopment = false): string => {
   const { csp } = securityConfig
+  const scriptSources = [...csp.scriptSrc]
+
+  if (isDevelopment) {
+    scriptSources.push("'unsafe-inline'")
+  }
 
   const directives = [
     `default-src ${csp.defaultSrc.join(" ")}`,
-    `script-src ${
-      isDevelopment
-        ? csp.scriptSrc.join(" ")
-        : csp.scriptSrc.filter((src) => !src.includes("unsafe")).join(" ")
-    }`,
+    `script-src ${scriptSources.join(" ")}`,
     `style-src ${csp.styleSrc.join(" ")}`,
     `img-src ${csp.imgSrc.join(" ")}`,
     `font-src ${csp.fontSrc.join(" ")}`,

--- a/vercel.json
+++ b/vercel.json
@@ -54,7 +54,7 @@
                 },
                 {
                     "key": "Content-Security-Policy",
-                    "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.emailjs.com https://va.vercel-scripts.com https://vitals.vercel-insights.com https://eu-assets.i.posthog.com https://app.posthog.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://api.emailjs.com https://va.vercel-scripts.com https://vitals.vercel-insights.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://app.posthog.com https://fonts.googleapis.com https://fonts.gstatic.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests;"
+                    "value": "default-src 'self'; script-src 'self' https://cdn.emailjs.com https://va.vercel-scripts.com https://vitals.vercel-insights.com https://eu-assets.i.posthog.com https://app.posthog.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://api.emailjs.com https://va.vercel-scripts.com https://vitals.vercel-insights.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://app.posthog.com https://fonts.googleapis.com https://fonts.gstatic.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests;"
                 },
                 {
                     "key": "Permissions-Policy",

--- a/vite.config.js
+++ b/vite.config.js
@@ -76,7 +76,7 @@ export default defineConfig({
     https: false,
     // Add headers for development
     headers: {
-      'Content-Security-Policy': "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.emailjs.com https://va.vercel-scripts.com https://vitals.vercel-insights.com https://eu-assets.i.posthog.com https://app.posthog.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://api.emailjs.com https://va.vercel-scripts.com https://vitals.vercel-insights.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://app.posthog.com https://fonts.googleapis.com https://fonts.gstatic.com; base-uri 'self'; form-action 'self'; object-src 'none';"
+      'Content-Security-Policy': "default-src 'self'; script-src 'self' https://cdn.emailjs.com https://va.vercel-scripts.com https://vitals.vercel-insights.com https://eu-assets.i.posthog.com https://app.posthog.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://api.emailjs.com https://va.vercel-scripts.com https://vitals.vercel-insights.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://app.posthog.com https://fonts.googleapis.com https://fonts.gstatic.com; base-uri 'self'; form-action 'self'; object-src 'none';"
     },
     // Preload important modules
     warmup: {


### PR DESCRIPTION
## Summary
- remove `script-src 'unsafe-inline'` from production CSP definitions in runtime/deploy configs
- consolidate middleware security headers to use shared `getAllSecurityHeaders(...)` from `src/utils/security.ts`
- remove duplicate CSP meta tag so policy is served consistently via HTTP headers

## Test plan
- [x] `npm run lint` (no errors)
- [x] `npm run build`
- [ ] Verify deployed response headers include CSP without `script-src 'unsafe-inline'`
- [ ] Run CSP evaluator against production URL and confirm no high-risk inline-script warning

Closes #5

Made with [Cursor](https://cursor.com)