### PR TITLE
fix: secure contact submissions with server-side protections

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,11 @@ npm install
 cp .env.example .env
 
 # Add your API keys to .env
-# VITE_EMAILJS_SERVICE_ID=your_service_id
-# VITE_EMAILJS_TEMPLATE_ID=your_template_id
-# VITE_EMAILJS_PUBLIC_KEY=your_public_key
+# EMAILJS_SERVICE_ID=your_service_id
+# EMAILJS_TEMPLATE_ID=your_template_id
+# EMAILJS_PUBLIC_KEY=your_public_key
+# CONTACT_EMAIL=your_email@example.com
+# PUBLIC_SITE_ORIGIN=https://theodorosmentis.com
 # VITE_POSTHOG_API_KEY=your_posthog_key
 # VITE_POSTHOG_HOST=https://eu.i.posthog.com
 ```
@@ -233,10 +235,12 @@ The project uses a modern design system with:
 Create a `.env` file in the root directory:
 
 ```env
-# EmailJS Configuration
-VITE_EMAILJS_SERVICE_ID=your_service_id
-VITE_EMAILJS_TEMPLATE_ID=your_template_id
-VITE_EMAILJS_PUBLIC_KEY=your_public_key
+# Contact API / EmailJS configuration (server-side)
+EMAILJS_SERVICE_ID=your_service_id
+EMAILJS_TEMPLATE_ID=your_template_id
+EMAILJS_PUBLIC_KEY=your_public_key
+CONTACT_EMAIL=your_email@example.com
+PUBLIC_SITE_ORIGIN=https://theodorosmentis.com
 
 # PostHog Analytics
 VITE_POSTHOG_API_KEY=your_posthog_key

--- a/api/contact/csrf.ts
+++ b/api/contact/csrf.ts
@@ -1,0 +1,83 @@
+import crypto from "node:crypto"
+
+type VercelRequest = {
+  method?: string
+  headers: Record<string, string | string[] | undefined>
+}
+
+type VercelResponse = {
+  status: (statusCode: number) => VercelResponse
+  json: (body: unknown) => void
+  setHeader: (name: string, value: string | string[]) => void
+}
+
+const CSRF_COOKIE_NAME = "contact_csrf_token"
+const TOKEN_TTL_MS = 30 * 60 * 1000
+
+const tokenStore = new Map<string, number>()
+
+function pruneExpiredTokens() {
+  const now = Date.now()
+  for (const [token, expiresAt] of tokenStore.entries()) {
+    if (expiresAt <= now) {
+      tokenStore.delete(token)
+    }
+  }
+}
+
+function createToken(): string {
+  return crypto.randomBytes(32).toString("hex")
+}
+
+function buildCookie(token: string): string {
+  const maxAge = TOKEN_TTL_MS / 1000
+  return `${CSRF_COOKIE_NAME}=${token}; Max-Age=${maxAge}; Path=/; HttpOnly; Secure; SameSite=Strict`
+}
+
+function extractCookieValue(cookieHeader: string | undefined, name: string): string {
+  if (!cookieHeader) {
+    return ""
+  }
+
+  const cookie = cookieHeader
+    .split(";")
+    .map((entry) => entry.trim())
+    .find((entry) => entry.startsWith(`${name}=`))
+
+  return cookie ? decodeURIComponent(cookie.split("=").slice(1).join("=")) : ""
+}
+
+export function verifyCsrf(req: VercelRequest, providedToken: string): boolean {
+  pruneExpiredTokens()
+
+  if (!providedToken) {
+    return false
+  }
+
+  const cookieHeader = Array.isArray(req.headers.cookie)
+    ? req.headers.cookie.join(";")
+    : req.headers.cookie
+  const cookieToken = extractCookieValue(cookieHeader, CSRF_COOKIE_NAME)
+
+  if (!cookieToken || cookieToken !== providedToken) {
+    return false
+  }
+
+  const expiresAt = tokenStore.get(providedToken)
+  return typeof expiresAt === "number" && expiresAt > Date.now()
+}
+
+export default function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== "GET") {
+    res.status(405).json({ error: "Method not allowed" })
+    return
+  }
+
+  pruneExpiredTokens()
+  const token = createToken()
+  tokenStore.set(token, Date.now() + TOKEN_TTL_MS)
+
+  res.setHeader("Cache-Control", "no-store")
+  res.setHeader("Set-Cookie", buildCookie(token))
+  res.status(200).json({ csrfToken: token })
+}

--- a/api/contact/index.ts
+++ b/api/contact/index.ts
@@ -1,0 +1,223 @@
+import { verifyCsrf } from "./csrf"
+import {
+  detectBot,
+  sanitizeContactFormData,
+  validateContactFormSecure,
+  type SecureContactFormData,
+} from "../../src/utils/secureContactValidation"
+
+type VercelRequest = {
+  method?: string
+  headers: Record<string, string | string[] | undefined>
+  body?: unknown
+  socket?: { remoteAddress?: string }
+}
+
+type VercelResponse = {
+  status: (statusCode: number) => VercelResponse
+  json: (body: unknown) => void
+}
+
+type ContactPayload = SecureContactFormData & {
+  csrfToken?: string
+}
+
+type RateLimitEntry = {
+  attempts: number
+  windowStart: number
+  blockedUntil?: number
+}
+
+const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000
+const RATE_LIMIT_MAX = 5
+const RATE_LIMIT_BLOCK_MS = 30 * 60 * 1000
+
+const rateLimitStore = new Map<string, RateLimitEntry>()
+
+function getHeader(req: VercelRequest, key: string): string {
+  const raw = req.headers[key]
+  if (Array.isArray(raw)) return raw[0] ?? ""
+  return raw ?? ""
+}
+
+function getClientIp(req: VercelRequest): string {
+  const forwardedFor = getHeader(req, "x-forwarded-for")
+  if (forwardedFor) {
+    return forwardedFor.split(",")[0].trim()
+  }
+  const realIp = getHeader(req, "x-real-ip")
+  return realIp || req.socket?.remoteAddress || "unknown"
+}
+
+function getRequestFingerprint(req: VercelRequest): string {
+  const ip = getClientIp(req)
+  const userAgent = getHeader(req, "user-agent") || "unknown"
+  return `${ip}:${userAgent}`
+}
+
+function cleanupRateLimits() {
+  const now = Date.now()
+  for (const [key, value] of rateLimitStore.entries()) {
+    if (value.blockedUntil && value.blockedUntil <= now) {
+      rateLimitStore.delete(key)
+      continue
+    }
+    if (!value.blockedUntil && now - value.windowStart > RATE_LIMIT_WINDOW_MS) {
+      rateLimitStore.delete(key)
+    }
+  }
+}
+
+function checkRateLimit(fingerprint: string): { allowed: boolean; retryAfterSec: number } {
+  cleanupRateLimits()
+  const now = Date.now()
+  const current = rateLimitStore.get(fingerprint)
+
+  if (!current) {
+    return { allowed: true, retryAfterSec: 0 }
+  }
+
+  if (current.blockedUntil && current.blockedUntil > now) {
+    return {
+      allowed: false,
+      retryAfterSec: Math.ceil((current.blockedUntil - now) / 1000),
+    }
+  }
+
+  if (now - current.windowStart > RATE_LIMIT_WINDOW_MS) {
+    return { allowed: true, retryAfterSec: 0 }
+  }
+
+  return {
+    allowed: current.attempts < RATE_LIMIT_MAX,
+    retryAfterSec: Math.ceil((current.windowStart + RATE_LIMIT_WINDOW_MS - now) / 1000),
+  }
+}
+
+function recordAttempt(fingerprint: string, shouldBlock = false) {
+  const now = Date.now()
+  const existing = rateLimitStore.get(fingerprint)
+
+  if (!existing || now - existing.windowStart > RATE_LIMIT_WINDOW_MS) {
+    rateLimitStore.set(fingerprint, {
+      attempts: 1,
+      windowStart: now,
+      blockedUntil: shouldBlock ? now + RATE_LIMIT_BLOCK_MS : undefined,
+    })
+    return
+  }
+
+  const attempts = existing.attempts + 1
+  rateLimitStore.set(fingerprint, {
+    attempts,
+    windowStart: existing.windowStart,
+    blockedUntil:
+      shouldBlock || attempts >= RATE_LIMIT_MAX ? now + RATE_LIMIT_BLOCK_MS : undefined,
+  })
+}
+
+function isAllowedOrigin(origin: string): boolean {
+  if (!origin) return false
+  const productionOrigin = process.env.PUBLIC_SITE_ORIGIN
+  if (productionOrigin && origin === productionOrigin) {
+    return true
+  }
+  return origin.startsWith("http://localhost:") || origin.startsWith("http://127.0.0.1:")
+}
+
+async function sendViaEmailJs(data: SecureContactFormData) {
+  const serviceId = process.env.EMAILJS_SERVICE_ID || process.env.VITE_EMAILJS_SERVICE_ID
+  const templateId = process.env.EMAILJS_TEMPLATE_ID || process.env.VITE_EMAILJS_TEMPLATE_ID
+  const publicKey = process.env.EMAILJS_PUBLIC_KEY || process.env.VITE_EMAILJS_PUBLIC_KEY
+  const toEmail = process.env.CONTACT_EMAIL || process.env.VITE_CONTACT_EMAIL
+
+  if (!serviceId || !templateId || !publicKey) {
+    throw new Error("Email provider is not configured")
+  }
+
+  const response = await fetch("https://api.emailjs.com/api/v1.0/email/send", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      service_id: serviceId,
+      template_id: templateId,
+      user_id: publicKey,
+      template_params: {
+        from_name: data.name,
+        from_email: data.email,
+        subject: data.subject,
+        message: data.message,
+        to_email: toEmail || "th.mentis@gmail.com",
+        reply_to: data.email,
+      },
+    }),
+  })
+
+  if (!response.ok) {
+    throw new Error(`EmailJS request failed with status ${response.status}`)
+  }
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== "POST") {
+    res.status(405).json({ error: "Method not allowed" })
+    return
+  }
+
+  const origin = getHeader(req, "origin")
+  if (!isAllowedOrigin(origin)) {
+    res.status(403).json({ error: "Invalid origin" })
+    return
+  }
+
+  const payload = (req.body || {}) as ContactPayload
+  const csrfToken = payload.csrfToken || getHeader(req, "x-csrf-token")
+  if (!verifyCsrf(req, csrfToken || "")) {
+    res.status(403).json({ error: "CSRF validation failed" })
+    return
+  }
+
+  const fingerprint = getRequestFingerprint(req)
+  const rateLimit = checkRateLimit(fingerprint)
+  if (!rateLimit.allowed) {
+    res.status(429).json({
+      error: "Too many submissions. Please try again later.",
+      retryAfterSeconds: rateLimit.retryAfterSec,
+    })
+    return
+  }
+
+  const secureData: SecureContactFormData = {
+    name: payload.name || "",
+    email: payload.email || "",
+    subject: payload.subject || "",
+    message: payload.message || "",
+    honeypot: payload.honeypot || "",
+    timestamp: payload.timestamp || 0,
+  }
+
+  if (detectBot(secureData)) {
+    recordAttempt(fingerprint, true)
+    res.status(400).json({ error: "Bot-like submission detected" })
+    return
+  }
+
+  const validation = validateContactFormSecure(secureData)
+  if (!validation.isValid) {
+    recordAttempt(fingerprint, false)
+    res.status(400).json({
+      error: "Validation failed",
+      fields: validation.errors,
+    })
+    return
+  }
+
+  const sanitized = sanitizeContactFormData(secureData)
+
+  try {
+    await sendViaEmailJs(sanitized)
+    res.status(200).json({ success: true })
+  } catch {
+    res.status(502).json({ error: "Email provider rejected the request" })
+  }
+}

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -2,7 +2,6 @@ import React, { memo, useState, useCallback, useMemo } from "react"
 import { useTheme } from "../context/ThemeContext"
 import useIntersectionObserver from "../hooks/useIntersectionObserver"
 import { motion, AnimatePresence } from "framer-motion"
-import emailjs from "@emailjs/browser"
 import {
   Mail,
   MapPin,
@@ -25,13 +24,7 @@ import {
   ContactFormErrors,
   validateContactFormSecure,
   detectBot,
-  sanitizeContactFormData,
 } from "../utils/secureContactValidation"
-import {
-  checkContactFormLimit,
-  recordContactFormAttempt,
-} from "../utils/enhancedRateLimit"
-import { CSRFProtection } from "../utils/enhancedCSRF"
 import { useToast } from "./ui/Toast"
 
 // SEO Schema generation for Contact section
@@ -287,9 +280,7 @@ const Contact: React.FC = memo(() => {
     "idle" | "success" | "error"
   >("idle")
 
-  const [csrfToken, setCsrfToken] = useState(() =>
-    CSRFProtection.getCurrentToken()
-  )
+  const [csrfToken, setCsrfToken] = useState("")
   const [honeypot, setHoneypot] = useState("")
   const [startTime] = useState(() => Date.now())
   const [touchedFields, setTouchedFields] = useState<Set<string>>(new Set())
@@ -308,11 +299,21 @@ const Contact: React.FC = memo(() => {
     return Object.values(fieldValidation).every(Boolean)
   }, [fieldValidation])
 
-  const emailjsConfig = {
-    serviceId: import.meta.env.VITE_EMAILJS_SERVICE_ID || "",
-    templateId: import.meta.env.VITE_EMAILJS_TEMPLATE_ID || "",
-    publicKey: import.meta.env.VITE_EMAILJS_PUBLIC_KEY || "",
-  }
+  const fetchCsrfToken = useCallback(async (): Promise<string> => {
+    const response = await fetch("/api/contact/csrf", {
+      method: "GET",
+      credentials: "same-origin",
+    })
+    if (!response.ok) {
+      throw new Error("Failed to initialize secure contact session")
+    }
+    const data = (await response.json()) as { csrfToken?: string }
+    if (!data.csrfToken) {
+      throw new Error("Missing CSRF token")
+    }
+    setCsrfToken(data.csrfToken)
+    return data.csrfToken
+  }, [])
 
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
@@ -350,27 +351,6 @@ const Contact: React.FC = memo(() => {
   }, [])
 
   const validateForm = useCallback((): boolean => {
-    const rateLimitResult = checkContactFormLimit("default")
-
-    if (!rateLimitResult.allowed) {
-      if (rateLimitResult.blocked) {
-        setErrors({
-          general:
-            rateLimitResult.message ||
-            "Too many attempts. Please try again later.",
-        })
-      } else {
-        setErrors({
-          general: `Rate limit exceeded. ${
-            rateLimitResult.remaining
-          } attempts remaining. Try again after ${new Date(
-            rateLimitResult.resetTime
-          ).toLocaleTimeString()}.`,
-        })
-      }
-      return false
-    }
-
     const secureData: SecureContactFormData = {
       ...formData,
       csrfToken,
@@ -400,22 +380,7 @@ const Contact: React.FC = memo(() => {
     async (e: React.FormEvent) => {
       e.preventDefault()
 
-      recordContactFormAttempt("default")
-
       if (!validateForm()) return
-
-      if (!CSRFProtection.isTokenValid(csrfToken)) {
-        const newToken = CSRFProtection.getCurrentToken()
-        setCsrfToken(newToken)
-
-        if (!CSRFProtection.isTokenValid(newToken)) {
-          setErrors({
-            general:
-              "Security validation failed. Please refresh the page and try again.",
-          })
-          return
-        }
-      }
 
       const submissionTime = Date.now() - startTime
       if (submissionTime < 3000) {
@@ -426,103 +391,50 @@ const Contact: React.FC = memo(() => {
         return
       }
 
-      if (
-        !emailjsConfig.serviceId ||
-        !emailjsConfig.templateId ||
-        !emailjsConfig.publicKey
-      ) {
-        if (!import.meta.env.DEV) {
-          setSubmitStatus("error")
-          setErrors({
-            general:
-              "Contact form is temporarily unavailable. Please email me directly.",
-          })
-          addToast({
-            type: "error",
-            title: "Contact Form Unavailable",
-            message:
-              "Please email me directly while the form configuration is being fixed.",
-            duration: 7000,
-          })
-          return
-        }
-
-        setIsSubmitting(true)
-        setSubmitStatus("idle")
-
-        try {
-          await new Promise((resolve) => setTimeout(resolve, 2000))
-
-          setCsrfToken(CSRFProtection.getCurrentToken())
-          recordContactFormAttempt("default", true)
-
-          setFormData({ name: "", email: "", subject: "", message: "" })
-          setSubmitStatus("success")
-          addToast({
-            type: "success",
-            title: "Message Sent!",
-            message: "Thank you for reaching out. I'll get back to you soon.",
-            duration: 5000,
-          })
-          setTimeout(() => setSubmitStatus("idle"), 5000)
-        } catch {
-          setSubmitStatus("error")
-          addToast({
-            type: "error",
-            title: "Failed to Send",
-            message: "Something went wrong. Please try again.",
-            duration: 6000,
-          })
-          setTimeout(() => setSubmitStatus("idle"), 5000)
-        } finally {
-          setIsSubmitting(false)
-        }
-        return
-      }
-
       setIsSubmitting(true)
       setSubmitStatus("idle")
 
       try {
-        if (!CSRFProtection.validateToken(csrfToken)) {
-          setErrors({
-            general:
-              "Security validation failed. Please refresh the page and try again.",
-          })
-          setIsSubmitting(false)
-          return
-        }
+        const token = csrfToken || (await fetchCsrfToken())
 
         const secureData: SecureContactFormData = {
           ...formData,
-          csrfToken,
+          csrfToken: token,
           timestamp: startTime, // Use the form's start time for bot detection
           honeypot,
         }
-        const sanitizedData = sanitizeContactFormData(secureData)
+        const response = await fetch("/api/contact", {
+          method: "POST",
+          credentials: "same-origin",
+          headers: {
+            "Content-Type": "application/json",
+            "X-CSRF-Token": token,
+          },
+          body: JSON.stringify(secureData),
+        })
 
-        const templateParams = {
-          from_name: sanitizedData.name,
-          from_email: sanitizedData.email,
-          subject: sanitizedData.subject,
-          message: sanitizedData.message,
-          to_email: import.meta.env.VITE_CONTACT_EMAIL || "th.mentis@gmail.com",
-          reply_to: sanitizedData.email,
+        if (!response.ok) {
+          const result = (await response.json().catch(() => ({}))) as {
+            error?: string
+            fields?: ContactFormErrors
+          }
+          if (response.status === 400 && result.fields) {
+            setErrors(result.fields)
+          } else {
+            setErrors({
+              general:
+                result.error ||
+                "Something went wrong. Please try again or email me directly.",
+            })
+          }
+          setSubmitStatus("error")
+          return
         }
-
-        await emailjs.send(
-          emailjsConfig.serviceId,
-          emailjsConfig.templateId,
-          templateParams,
-          emailjsConfig.publicKey
-        )
-
-        setCsrfToken(CSRFProtection.getCurrentToken())
-        recordContactFormAttempt("default", true)
 
         setFormData({ name: "", email: "", subject: "", message: "" })
         setErrors({})
         setSubmitStatus("success")
+        setCsrfToken("")
         addToast({
           type: "success",
           title: "Message Sent!",
@@ -548,11 +460,11 @@ const Contact: React.FC = memo(() => {
     [
       formData,
       validateForm,
-      emailjsConfig,
       csrfToken,
       startTime,
-      setCsrfToken,
+      fetchCsrfToken,
       addToast,
+      honeypot,
     ]
   )
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
     "rewrites": [
         {
-            "source": "/((?!sw\\.js$).*)",
+            "source": "/((?!api/|sw\\.js$).*)",
             "destination": "/index.html"
         }
     ],

--- a/vite.config.js
+++ b/vite.config.js
@@ -32,8 +32,6 @@ export default defineConfig({
           // Utils and smaller dependencies
           'utils': ['react-typed'],
 
-          // EmailJS (only loaded when contact form is used)
-          'emailjs': ['@emailjs/browser'],
         },
         // Optimize chunk file names
         chunkFileNames: (chunkInfo) => {


### PR DESCRIPTION
## Summary
- route contact form submissions through server-controlled endpoints (`/api/contact/csrf` and `/api/contact`)
- enforce CSRF validation, bot checks, and server-side rate limiting/validation before forwarding to EmailJS
- remove direct browser EmailJS send path and update SPA rewrites so API routes are reachable in production

## Test plan
- [x] `npm run lint` (no errors)
- [x] `npm run build`
- [ ] Submit valid contact form in preview and verify success response from `/api/contact`
- [ ] Confirm repeated spam-like or rapid submissions receive `429`/rejection from server
- [ ] Confirm invalid edits do not consume send quota (validation fails before provider call)

Closes #35

Made with [Cursor](https://cursor.com)