### PR TITLE
fix: align COEP policy with third-party integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ A high-performance, accessible portfolio website built with modern web technolog
 - **Vercel Analytics** - Performance tracking
 - **Service Workers** - Offline functionality
 
+### Deployment Header Notes
+
+- **Cross-Origin-Embedder-Policy**: Uses `credentialless` in production headers.
+- **Why not `require-corp`**: The site loads third-party analytics and contact-provider resources that may not return compatible CORP/CORS headers in every path.
+- **Security stance**: Keep strict CSP and other security headers, but avoid unnecessary cross-origin isolation requirements that can block analytics/contact behavior.
+
 ### Development Tools
 
 - **ESLint** - Code quality enforcement

--- a/vercel.json
+++ b/vercel.json
@@ -62,7 +62,7 @@
                 },
                 {
                     "key": "Cross-Origin-Embedder-Policy",
-                    "value": "require-corp"
+                    "value": "credentialless"
                 },
                 {
                     "key": "Cross-Origin-Opener-Policy",


### PR DESCRIPTION
## Summary
- switch deployment `Cross-Origin-Embedder-Policy` from `require-corp` to `credentialless` in `vercel.json`
- keep strict CSP and other security headers intact while reducing risk of third-party resource blocking
- document header policy rationale in `README.md` for future regressions and reviews

## Test plan
- [x] `npm run lint` (no errors)
- [x] `npm run build`
- [x] Verify production/preview console has no COEP/CORP blocked-resource errors
- [x] Confirm contact form submit and analytics network requests succeed in preview

Closes #37

Made with [Cursor](https://cursor.com)