### PR TITLE
fix: correct hero CTA accessibility labels and targets

### DIFF
--- a/src/components/Hero.test.tsx
+++ b/src/components/Hero.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react"
+import Hero from "./Hero"
+import { ThemeProvider } from "../context/ThemeContext"
+
+describe("Hero CTA accessibility", () => {
+  it("matches CTA labels with their destination anchors", () => {
+    render(
+      <ThemeProvider>
+        <Hero />
+      </ThemeProvider>
+    )
+
+    const startProjectCta = screen.getByLabelText(
+      "Start a Project - jump to contact form"
+    )
+    const viewWorkCta = screen.getByLabelText(
+      "View My Work - jump to portfolio projects"
+    )
+
+    expect(startProjectCta).toHaveAttribute("href", "#contact")
+    expect(viewWorkCta).toHaveAttribute("href", "#projects")
+  })
+})

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -166,7 +166,7 @@ const Hero: React.FC = memo(() => {
 
           <div className="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start">
             <a
-              href="#projects"
+              href="#contact"
               className={`group relative px-8 py-4 rounded-xl font-semibold text-white overflow-hidden transition-all duration-300 transform hover:scale-105 focus:outline-none focus:ring-4 focus:ring-blue-500/50 ${
                 isDark
                   ? "bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-500 hover:to-purple-500"
@@ -182,7 +182,7 @@ const Hero: React.FC = memo(() => {
             </a>
 
             <a
-              href="#contact"
+              href="#projects"
               className={`px-8 py-4 rounded-xl font-semibold border-2 transition-all duration-300 transform hover:scale-105 focus:outline-none focus:ring-4 focus:ring-blue-500/50 ${
                 isDark
                   ? "border-slate-600 text-slate-300 hover:border-blue-400 hover:text-blue-400 hover:bg-blue-400/10"

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -13,3 +13,15 @@ Object.defineProperty(window, "matchMedia", {
     dispatchEvent: () => false,
   }),
 })
+
+class MockIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+Object.defineProperty(window, "IntersectionObserver", {
+  writable: true,
+  configurable: true,
+  value: MockIntersectionObserver,
+})


### PR DESCRIPTION
## Summary
- align Hero CTA destinations with their accessible names (`Start a Project` -> `#contact`, `View My Work` -> `#projects`)
- add `Hero` regression test asserting CTA aria labels and href targets stay consistent
- add `IntersectionObserver` test mock in setup for stable component testing

## Test plan
- [x] `npm run test -- Hero.test.tsx`
- [x] `npm run lint` (no errors)
- [x] `npm run build`

Closes #36

Made with [Cursor](https://cursor.com)