### PR TITLE
fix: prevent service worker precache install failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ npm run type-check
 
 # Check project URLs
 npm run check-urls
+
+# Verify service worker pre-cache assets after build
+npm run build && npm run verify:sw-precache
 ```
 
 ## 📁 Project Structure

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:ci": "npm run test && npm run test:smoke",
     "clean": "npx rimraf dist node_modules/.vite",
     "check-urls": "node scripts/check-project-urls.js",
+    "verify:sw-precache": "node scripts/verify-sw-precache.js",
     "validate:project-data": "node scripts/validate-project-data.js",
     "performance:analyze": "npm run build && npx vite-bundle-visualizer -o bundle-report.html",
     "deploy:redirect": "echo 'Deploying redirect page to GitHub Pages...' && git add redirect.html .github/workflows/redirect-deploy.yml && git commit -m 'deploy: update GitHub Pages redirect' && git push"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "Theodoros Mentis Portfolio",
+  "short_name": "Portfolio",
+  "description": "Senior Full-Stack Developer portfolio site",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#1f2937",
+  "icons": [
+    {
+      "src": "/favicon.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/favicon.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -53,7 +53,19 @@ self.addEventListener('install', (event) => {
         Promise.all([
             // Cache static assets
             caches.open(STATIC_CACHE).then(cache => {
-                return cache.addAll(STATIC_ASSETS)
+                return Promise.all(
+                    STATIC_ASSETS.map(async (asset) => {
+                        try {
+                            const response = await fetch(asset, { cache: 'no-store' })
+                            if (!response.ok) {
+                                throw new Error(`HTTP ${response.status}`)
+                            }
+                            await cache.put(asset, response.clone())
+                        } catch (error) {
+                            console.warn(`⚠️ Skipping pre-cache for ${asset}:`, error)
+                        }
+                    })
+                )
             }),
 
             // Skip font preloading to avoid CSP issues during install

--- a/scripts/verify-sw-precache.js
+++ b/scripts/verify-sw-precache.js
@@ -1,0 +1,47 @@
+import fs from "node:fs"
+import path from "node:path"
+
+const projectRoot = process.cwd()
+const swPath = path.join(projectRoot, "public", "sw.js")
+const distDir = path.join(projectRoot, "dist")
+
+function readStaticAssets() {
+  const swContent = fs.readFileSync(swPath, "utf8")
+  const match = swContent.match(/const\s+STATIC_ASSETS\s*=\s*\[([\s\S]*?)\]/)
+  if (!match) {
+    throw new Error("Could not find STATIC_ASSETS in public/sw.js")
+  }
+
+  const assetsBlock = match[1]
+  const assets = []
+  const regex = /['"]([^'"]+)['"]/g
+  let item = regex.exec(assetsBlock)
+  while (item) {
+    assets.push(item[1])
+    item = regex.exec(assetsBlock)
+  }
+  return assets
+}
+
+function toDistPath(asset) {
+  if (asset === "/") {
+    return path.join(distDir, "index.html")
+  }
+  return path.join(distDir, asset.replace(/^\//, ""))
+}
+
+function verifyAssetsExist() {
+  const assets = readStaticAssets()
+  const missing = assets.filter((asset) => !fs.existsSync(toDistPath(asset)))
+
+  if (missing.length > 0) {
+    console.error("❌ Missing pre-cache asset(s) in dist:")
+    missing.forEach((asset) => console.error(` - ${asset}`))
+    process.exit(1)
+  }
+
+  console.log("✅ All service worker pre-cache assets exist in dist:")
+  assets.forEach((asset) => console.log(` - ${asset}`))
+}
+
+verifyAssetsExist()


### PR DESCRIPTION
## Summary
- add `public/manifest.json` so precached `/manifest.json` resolves in production
- harden `public/sw.js` install phase to cache static assets individually and skip failing entries instead of aborting the entire install
- add `scripts/verify-sw-precache.js` plus `npm run verify:sw-precache` to verify all `STATIC_ASSETS` exist in build output

## Test plan
- [x] `npm run lint` (no errors)
- [x] `npm run build`
- [x] `npm run verify:sw-precache`
- [ ] Manual check in preview: service worker reaches `activated` state without install errors

Closes #32

Made with [Cursor](https://cursor.com)