### PR TITLE
test: make Playwright smoke checks self-contained

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,9 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Smoke tests
+        run: npm run test:smoke

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "type-check": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
+    "pretest:smoke": "playwright install --with-deps chromium || playwright install chromium",
     "test:smoke": "playwright test",
     "test:ci": "npm run test && npm run test:smoke",
     "clean": "npx rimraf dist node_modules/.vite",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,8 +3,14 @@ import { defineConfig } from "@playwright/test"
 export default defineConfig({
   testDir: "./e2e",
   timeout: 30_000,
+  webServer: {
+    command: "npm run build && npm run preview -- --host 127.0.0.1 --port 4173 --strictPort",
+    url: "http://127.0.0.1:4173",
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
   use: {
-    baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://localhost:4173",
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://127.0.0.1:4173",
     headless: true,
   },
 })


### PR DESCRIPTION
## Summary
- add Playwright `webServer` in `playwright.config.ts` to build and start `vite preview` automatically (or reuse existing server)
- ensure `npm run test:smoke` installs Chromium first via `pretest:smoke`
- update CI workflow to install Playwright browser deps and run smoke tests after build

## Test plan
- [x] `npm run lint` (no errors)
- [x] `npm run build`
- [x] `npm run test:smoke` starts setup automatically (browser dependency still environment-dependent locally)
- [ ] Verify CI smoke step passes with Playwright browser install step

Closes #33

Made with [Cursor](https://cursor.com)