### PR TITLE
chore: remove git-mutating redirect deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,14 @@ VITE_ENABLE_MONITORING=true
 - [PRD](PRD.md) - Product requirements document
 - [Deployment Notes](src/docs/DEPLOYMENT.md) - Deployment guides
 
+## Redirect Deployment
+
+- Redirect publishing is handled by `.github/workflows/redirect-deploy.yml`.
+- Safe options:
+  - Commit `redirect.html` changes and push to `main` (workflow runs automatically).
+  - Trigger manually with `npm run deploy:redirect:trigger` (requires GitHub CLI auth).
+- `npm run deploy:redirect` is informational only and does not run `git add`, `git commit`, or `git push`.
+
 ## 🤝 Contributing
 
 This is a personal portfolio project, but suggestions and feedback are welcome! Feel free to open an issue or reach out via email.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "verify:sw-precache": "node scripts/verify-sw-precache.js",
     "validate:project-data": "node scripts/validate-project-data.js",
     "performance:analyze": "npm run build && npx vite-bundle-visualizer -o bundle-report.html",
-    "deploy:redirect": "echo 'Deploying redirect page to GitHub Pages...' && git add redirect.html .github/workflows/redirect-deploy.yml && git commit -m 'deploy: update GitHub Pages redirect' && git push"
+    "deploy:redirect": "echo 'Redirect deployment is handled by .github/workflows/redirect-deploy.yml. Commit redirect.html changes and push to main, or run: gh workflow run redirect-deploy.yml'",
+    "deploy:redirect:trigger": "gh workflow run redirect-deploy.yml"
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",


### PR DESCRIPTION
## Summary
- replace `deploy:redirect` so it no longer runs `git add`, `git commit`, or `git push`
- add `deploy:redirect:trigger` to explicitly trigger `redirect-deploy.yml` via GitHub CLI
- document safe redirect deployment options in `README.md`

## Test plan
- [x] `npm run lint` (no errors)
- [x] Confirm `package.json` scripts contain no `git commit`/`git push` deployment behavior
- [x] Confirm redirect deployment remains possible via workflow trigger or commit-to-main path

Closes #11

Made with [Cursor](https://cursor.com)